### PR TITLE
chore: Convert Airflow connections to env-based config in docker-compose

### DIFF
--- a/airflow/plugins/connection_utils.py
+++ b/airflow/plugins/connection_utils.py
@@ -26,7 +26,7 @@ CONNECTION_CONFIG = {
 # -------------------------------------------------------------------------
 # Environment Resolver
 # -------------------------------------------------------------------------
-DEFAULT_ENV = "aws"
+DEFAULT_ENV = "local"
 
 
 def get_current_env() -> str:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -89,6 +89,14 @@ x-airflow-common:
     _PIP_ADDITIONAL_REQUIREMENTS: ${_PIP_ADDITIONAL_REQUIREMENTS:-}
     # The following line can be used to set a custom config file, stored in the local config folder
     AIRFLOW_CONFIG: '/opt/airflow/config/airflow.cfg'
+    # docker-compose.yml
+
+    # Airflow 커넥션 정보 등록
+    # MinIO 커넥션 : minio_conn
+    AIRFLOW_CONN_MINIO_CONN: '{"conn_type":"aws","login":"${_MINIO_WWW_USER_USERNAME}","password":"${_MINIO_WWW_USER_PASSWORD}","extra":{"endpoint_url":"http://minio:9000"}}'
+    # Trino 커넥션 : trino_conn
+    AIRFLOW_CONN_TRINO_CONN: 'trino://admin@trino:8080/hive'
+  
   volumes:
     - ${AIRFLOW_PROJ_DIR:-.}/airflow/dags:/opt/airflow/dags        # [CHANGED] 볼륨 mount 위치 변경
     - ${AIRFLOW_PROJ_DIR:-.}/airflow/logs:/opt/airflow/logs        # [CHANGED] 볼륨 mount 위치 변경


### PR DESCRIPTION
## ✨ What
- airflow connections 연결정보를 docker compose 환경변수로 관리가능하도록 변환

## 🎯 Why
- 서비스 구동 시, 별도의 연결 등록 작업 없이 동작할 수 있도록 변경
- 링크: Closes #12

## 📌 Changes
- docker compose 파일 내 연결정보 환경변수 삽입 (MinIO / Trino)

## 🧪 Test
1. git pull 받은 후, docker compose 재실행 
2. 기존 로컬 airflow에 UI로 등록되어 있던 연결정보 삭제
3. MinIO 연결 테스트 : `test_storage_conn` dag 실행하여 정상연결 확인
4. Trino 연결 테스트  : `test_trino_conn` dag 실행하여 정상연결 확인